### PR TITLE
Fixed the dependencies

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -15,7 +15,8 @@ object ScalaFlowBuild extends Build {
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-reflect" % "2.10.4",
       "com.twitter" %% "chill" % "0.5.1",
-      "com.google.cloud.dataflow" % "google-cloud-dataflow-java-sdk-all" % "manual_build",
+      "org.joda" % "joda-convert" % "1.2",
+      "com.google.cloud.dataflow" % "google-cloud-dataflow-java-sdk-all" % "0.3.141216",
       // test dependencies
       "org.scalatest" %% "scalatest" % "2.2.1" % "test",
       "org.hamcrest" % "hamcrest-all" % "1.3" % "test",


### PR DESCRIPTION
Hello,

Using Google Cloud Dataflow Java SDK with current versions 0.4.\* breaks compilation. I get the following errors right out of the box:

```
[warn] Class org.joda.convert.FromString not found - continuing with a stub.
[warn] Class org.joda.convert.ToString not found - continuing with a stub.
[error] /home/user/Documents/scalaflow/src/main/scala/me/juhanlol/dataflow/CoderRegistry.scala:44: not found: type URICoder
[error]   registerCoder[URI](classOf[URICoder])
[error]                              ^
[error] /home/user/Documents/scalaflow/src/main/scala/me/juhanlol/dataflow/examples/JavaStyleWordCount.scala:30: wrong number of type arguments for com.google.cloud.dataflow.sdk.transforms.Aggregator, should be 2
[error]   var emptyLines: Aggregator[java.lang.Long] = _
[error]                   ^
[error] /home/user/Documents/scalaflow/src/main/scala/me/juhanlol/dataflow/examples/JavaStyleWordCount.scala:33: value createAggregator is not a member of ExtractWordsFn.this.Context
[error]     emptyLines = c.createAggregator("emptyLines", new Sum.SumLongFn())
[error]                    ^
[warn] two warnings found
[error] three errors found
[error] (compile:compileIncremental) Compilation failed
[error] Total time: 5 s, completed Jul 12, 2015 7:00:45 PM
```

It looks like it is required to specify that the example uses [0.3.141216](http://mvnrepository.com/artifact/com.google.cloud.dataflow/google-cloud-dataflow-java-sdk-all) version. Once specified, `sbt` compiles, tests and runs everything successfully.

Thanks for consideration!
